### PR TITLE
[feat/#4] 소비레포트 화면 구성

### DIFF
--- a/t3-front/src/App.tsx
+++ b/t3-front/src/App.tsx
@@ -5,14 +5,8 @@ import LoginSuccessPage from "./pages/Login/LoginSuccessPage";
 import ReportPage from "./pages/ReportPage";
 import ChattingPage from "./pages/chatting/ChattingPage";
 import LoginPage from "./pages/Login/LoginPage";
-import AddPage from "./pages/AddPage";
-import ChattingListPage from "./pages/chatting/ChattingListPage";
-import UpdateGoalPage from "./pages/UpdateGoalPage";
-import UpdateTargetAmountPage from "./pages/UpdateTargetAmountPage";
-import ChangeCharacterPage from "./pages/chatting/UpdateCharacterPage";
-import CreateNewChattingPage from "./pages/chatting/CreateNewChattingPage";
-import NewChattingPage from "./pages/chatting/NewChattingPage";
-
+import IncomeDetailPage from "./pages/IncomeDetailPage";
+import CategoryDetailPage from "./pages/CategoryDetailPage";
 function App() {
   return (
     <BrowserRouter>
@@ -23,17 +17,9 @@ function App() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/login-success" element={<LoginSuccessPage />} />
           <Route path="/report" element={<ReportPage />} />
-          <Route path="/chatting/:roomId" element={<ChattingPage />} />
-          <Route path="/chatting-list" element={<ChattingListPage />} />
-          <Route path="/add" element={<AddPage />} />
-          <Route path="/update-goal" element={<UpdateGoalPage />} />
-          <Route path="/update-amount" element={<UpdateTargetAmountPage />} />
-          <Route
-            path="/chatting/:roomId/update-character"
-            element={<ChangeCharacterPage />}
-          />
-          <Route path="/chatting/new" element={<CreateNewChattingPage />} />
-          <Route path="/chatting/new/message" element={<NewChattingPage />} />
+          <Route path="/income" element={<IncomeDetailPage />} />
+          <Route path="/chatting" element={<ChattingPage />} />
+          <Route path="/report/category/:categoryName" element={<CategoryDetailPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/t3-front/src/App.tsx
+++ b/t3-front/src/App.tsx
@@ -7,6 +7,13 @@ import ChattingPage from "./pages/chatting/ChattingPage";
 import LoginPage from "./pages/Login/LoginPage";
 import IncomeDetailPage from "./pages/IncomeDetailPage";
 import CategoryDetailPage from "./pages/CategoryDetailPage";
+import AddPage from "./pages/AddPage";
+import ChattingListPage from "./pages/chatting/ChattingListPage";
+import UpdateGoalPage from "./pages/UpdateGoalPage";
+import UpdateTargetAmountPage from "./pages/UpdateTargetAmountPage";
+import ChangeCharacterPage from "./pages/chatting/UpdateCharacterPage";
+import CreateNewChattingPage from "./pages/chatting/CreateNewChattingPage";
+import NewChattingPage from "./pages/chatting/NewChattingPage";
 function App() {
   return (
     <BrowserRouter>
@@ -20,6 +27,17 @@ function App() {
           <Route path="/income" element={<IncomeDetailPage />} />
           <Route path="/chatting" element={<ChattingPage />} />
           <Route path="/report/category/:categoryName" element={<CategoryDetailPage />} />
+          <Route path="/chatting/:roomId" element={<ChattingPage />} />
+          <Route path="/chatting-list" element={<ChattingListPage />} />
+          <Route path="/add" element={<AddPage />} />
+          <Route path="/update-goal" element={<UpdateGoalPage />} />
+          <Route path="/update-amount" element={<UpdateTargetAmountPage />} />
+          <Route
+            path="/chatting/:roomId/update-character"
+            element={<ChangeCharacterPage />}
+          />
+          <Route path="/chatting/new" element={<CreateNewChattingPage />} />
+          <Route path="/chatting/new/message" element={<NewChattingPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/t3-front/src/components/charts/CategoryDonutChart.tsx
+++ b/t3-front/src/components/charts/CategoryDonutChart.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+
+interface Props {
+  data: number[];       // [135000, 90000, 45000, 30000]
+  colors: string[];     // ["#FF9F5B", "#FFD86E", ...]
+  centerText: string;   // "350,000"
+}
+
+const CategoryDonutChart = ({ data, colors, centerText }: Props) => {
+  const total = data.reduce((sum, v) => sum + v, 0);
+  const radius = 55;
+  const circumference = 2 * Math.PI * radius;
+
+  // 각 항목별 퍼센트 → stroke-dasharray 로 변환
+  let offset = 0;
+  const segments = data.map((value, index) => {
+    const percent = value / total;
+    const arcLength = percent * circumference;
+    const segment = {
+      color: colors[index],
+      dash: `${arcLength} ${circumference - arcLength}`,
+      offset,
+    };
+    offset += arcLength;
+    return segment;
+  });
+
+  return (
+    <div className="relative w-48 h-48 flex items-center justify-center">
+      <svg className="w-full h-full rotate-[-90deg]">
+        <circle
+          cx="50%"
+          cy="50%"
+          r={radius}
+          fill="transparent"
+          stroke="#EDEDED"
+          strokeWidth="20"
+        />
+
+        {segments.map((seg, idx) => (
+          <circle
+            key={idx}
+            cx="50%"
+            cy="50%"
+            r={radius}
+            fill="transparent"
+            stroke={seg.color}
+            strokeWidth="20"
+            strokeDasharray={seg.dash}
+            strokeDashoffset={-seg.offset}
+            strokeLinecap="butt"
+          />
+        ))}
+      </svg>
+
+      {/* 가운데 텍스트 */}
+      <span className="absolute text-text-primary font-semibold text-[16px]">
+        {centerText}
+      </span>
+    </div>
+  );
+};
+
+export default CategoryDonutChart;

--- a/t3-front/src/components/charts/ProgressCircle.tsx
+++ b/t3-front/src/components/charts/ProgressCircle.tsx
@@ -57,11 +57,11 @@ export default function ProgressCircle({
           </span>
         </div>
       ) : (
-        <div className="absolute flex items-end gap-[2px] translate-y-[18px]">
-          <span className="text-text-green font-bold text-[6rem] leading-none">
+        <div className="absolute flex items-end gap-[2px] translate-y-[10px]">
+          <span className="text-text-green font-bold text-2xl leading-none">
             {percent}
           </span>
-          <span className="text-text-gray font-semibold text-[4rem] leading-none">
+          <span className="text-text-gray font-semibold text-lg leading-none">
             {UNITS.PERCENT}
           </span>
         </div>

--- a/t3-front/src/components/common/Card.tsx
+++ b/t3-front/src/components/common/Card.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 
-interface CardProps {
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   className?: string;
 }
 
-const Card = ({ children, className = "" }: CardProps) => {
+const Card = ({ children, className = "", ...props }: CardProps) => {
   return (
     <div
       className={`flex justify-start rounded-xl bg-white-default p-4 ${className}`}
+      {...props}
     >
       {children}
     </div>

--- a/t3-front/src/layouts/MainLayout.tsx
+++ b/t3-front/src/layouts/MainLayout.tsx
@@ -22,6 +22,7 @@ const MainLayout: React.FC = () => {
     "/update-character",
     "/chatting/new",
     "/chatting/new/message",
+    "/income",
   ];
   const WHITE_BG_PATHS = [
     "/login",
@@ -74,11 +75,10 @@ const MainLayout: React.FC = () => {
                     }
                   />
                   <span
-                    className={`text-sm mt-1 ${
-                      isActive
-                        ? "text-primary-green font-semibold"
-                        : "text-text-gray"
-                    }`}
+                    className={`text-sm mt-1 ${isActive
+                      ? "text-primary-green font-semibold"
+                      : "text-text-gray"
+                      }`}
                   >
                     {tab.name}
                   </span>

--- a/t3-front/src/pages/CategoryDetailPage.tsx
+++ b/t3-front/src/pages/CategoryDetailPage.tsx
@@ -1,0 +1,131 @@
+import { useParams, useNavigate } from "react-router-dom";
+import Card from "../components/common/Card";
+import ProgressCircle from "../components/charts/ProgressCircle";
+import { IMAGES } from "../constants";
+import { formatCurrency } from "../utils/";
+
+const CategoryDetailPage = () => {
+    const { categoryName } = useParams();
+    const navigate = useNavigate();
+
+    const totalAmount = 135000;
+    const percent = 25;
+    const totalCount = 12;
+    const totalCountPercent = 56;
+
+    const dailyHistory = [
+        {
+            date: "10월 20일",
+            list: [
+                { name: "디저트월드", category: "식비", amount: -10000 },
+                { name: "오커스토리", category: "식비", amount: -13000 },
+            ],
+        },
+        {
+            date: "10월 15일",
+            list: [
+                { name: "돈까스정원", category: "식비", amount: -15000 },
+                { name: "친구커피", category: "식비", amount: -26000 },
+            ],
+        },
+    ];
+
+    return (
+        <div className="p-4 flex flex-col gap-4 bg-app-bg pb-6">
+
+            {/* Header */}
+            <div className="relative flex items-center py-2 mb-2">
+                <button className="text-2xl absolute left-0" onClick={() => navigate(-1)}>
+                    &lt;
+                </button>
+                <p className="text-lg font-semibold absolute left-1/2 -translate-x-1/2">
+                    세부내역
+                </p>
+            </div>
+
+            {/* 카테고리명 */}
+            <p className="text-text-gray text-sm">{categoryName}</p>
+
+            {/* 총 금액 */}
+            <p className="text-primary-green text-3xl font-bold">
+                {formatCurrency(totalAmount)}원
+            </p>
+
+            {/* --- 🔥 1번째 카드 : 분석 텍스트 & 개구리 --- */}
+            <Card className="p-5 flex justify-between items-start">
+                <div>
+                    <p className="text-text-gray text-sm">
+                        데이터의 <span className="text-primary-green font-semibold">{categoryName}</span> 소비 분석
+                    </p>
+
+                    <p className="text-text-primary text-sm leading-[1.3] mt-2">
+                        야식으로 지출을 너무 자주 먹네요. <br />
+                        야식을 3번 줄여봐요!
+                    </p>
+                </div>
+
+                <img
+                    src={IMAGES.MASCOT.HALF.DAY}
+                    className="
+                    absolute
+                    right-8
+                    w-[125px]
+                    h-[125px]
+                    object-contain
+                    translate-y-[-9px]     /* 살짝 아래로 내려서 자연스럽게 */
+                    "
+                    alt="frog mascot"
+                />
+            </Card>
+
+            {/* --- 🔥 2번째 & 3번째 카드 : 반원차트 + 전체 개수 --- */}
+            <div className="grid grid-cols-2 gap-3">
+
+                {/* 반원차트 */}
+                <Card className="flex flex-col items-center justify-center py-5">
+                    <p className="text-text-gray text-xs mb-2">
+                        전체 지출 10번 중 비율
+                    </p>
+
+                    {/* 글씨 크기 줄이기 */}
+                    <ProgressCircle current={percent} goal={100} mode="percent" />
+                </Card>
+
+                {/* 전체 소비 개수 */}
+                <Card className="flex flex-col items-center justify-center py-5">
+                    <p className="text-text-gray text-xs">이번달 전체 소비 개수</p>
+
+                    <p className="text-primary-green text-2xl font-bold mt-1">
+                        총 {totalCount}개
+                    </p>
+
+                    <p className="text-text-gray text-sm mt-1">
+                        {totalCountPercent}%
+                    </p>
+                </Card>
+            </div>
+
+            {/* --- 🔥 날짜별 내역 카드들 --- */}
+            {dailyHistory.map((day, idx) => (
+                <Card key={idx} className="p-4 flex flex-col gap-3">
+                    <p className="text-text-gray text-sm font-semibold">{day.date}</p>
+
+                    {day.list.map((item, i) => (
+                        <div key={i} className="flex justify-between items-center">
+                            <div className="flex flex-col">
+                                <span className="font-medium">{item.name}</span>
+                                <span className="text-xs text-text-gray">{item.category}</span>
+                            </div>
+
+                            <span className="text-primary-red font-semibold">
+                                {formatCurrency(item.amount)}원
+                            </span>
+                        </div>
+                    ))}
+                </Card>
+            ))}
+        </div>
+    );
+};
+
+export default CategoryDetailPage;

--- a/t3-front/src/pages/CategoryDetailPage.tsx
+++ b/t3-front/src/pages/CategoryDetailPage.tsx
@@ -58,7 +58,7 @@ const CategoryDetailPage = () => {
     >([]);
 
     const [totalCount, setTotalCount] = useState(0);
-
+    const [plannedCount, setPlannedCount] = useState(0);
     // ==================================================
     // 1) 카테고리 피드백 로딩
     // ==================================================
@@ -125,6 +125,8 @@ const CategoryDetailPage = () => {
 
                 setTotalCount(filtered.length);
 
+                const planned = filtered.filter((item) => item.planType === "PLANNED");
+                setPlannedCount(planned.length);
                 // 날짜별 묶기
                 const dailyMap: Record<string, any[]> = {};
 
@@ -174,6 +176,9 @@ const CategoryDetailPage = () => {
     };
 
     const koreanMascotStatus = mascotStatusToKorean[mascotStatus] || mascotStatus;
+    const plannedPercent =
+        totalCount > 0 ? Math.round((plannedCount / totalCount) * 100) : 0;
+
     // ==================================================
     // UI 
     // ==================================================
@@ -243,10 +248,10 @@ const CategoryDetailPage = () => {
                     {/* 가운데 영역 */}
                     <div className="flex flex-col items-center justify-center flex-1 mt-2">
                         <p className={`text-2xl font-bold ${currentColor}`}>
-                            총 {totalCount}개
+                            총 {plannedCount}개
                         </p>
 
-                        <p className="text-text-gray text-sm mt-1">{percent}%</p>
+                        <p className="text-text-gray text-sm mt-1">{plannedPercent}%</p>
                     </div>
                 </Card>
             </div>

--- a/t3-front/src/pages/CategoryDetailPage.tsx
+++ b/t3-front/src/pages/CategoryDetailPage.tsx
@@ -1,41 +1,176 @@
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import Card from "../components/common/Card";
 import ProgressCircle from "../components/charts/ProgressCircle";
 import { IMAGES } from "../constants";
 import { formatCurrency } from "../utils/";
+import { getMonthlyFeedback, getTransaction } from "../api";
+import { useEffect, useState } from "react";
+import {
+    ExpenseCategory,
+    ExpenseCategoryLabel,
+} from "../types";
+import type { ExpenseCategoryType, CategoryType } from "../types";
+
+
+// ==================================================
+//  1) 한글 라벨 → 영어 카테고리 KEY 역변환 함수
+//     예: "식비" → "FOOD"
+// ==================================================
+const findCategoryKeyByLabel = (
+    label: string
+): keyof typeof ExpenseCategoryLabel | null => {
+    return (
+        (Object.keys(ExpenseCategoryLabel) as (keyof typeof ExpenseCategoryLabel)[])
+            .find((key) => ExpenseCategoryLabel[key] === label) || null
+    );
+};
+
+// ==================================================
+//  2) CategoryType narrowing 함수
+// ==================================================
+const isExpenseCategory = (
+    category: CategoryType
+): category is ExpenseCategoryType => {
+    return (Object.values(ExpenseCategory) as string[]).includes(category);
+};
+
 
 const CategoryDetailPage = () => {
     const { categoryName } = useParams();
     const navigate = useNavigate();
+    const { state } = useLocation();
 
-    const totalAmount = 135000;
-    const percent = 25;
-    const totalCount = 12;
-    const totalCountPercent = 56;
+    // ReportPage에서 받은 값
+    // label = "식비"
+    const { label, amount, year, month, percent, mascotStatus } = state || {};
 
-    const dailyHistory = [
+    const [evaluation, setEvaluation] = useState("");
+    const [advice, setAdvice] = useState("");
+
+    const [dailyHistory, setDailyHistory] = useState<
         {
-            date: "10월 20일",
-            list: [
-                { name: "디저트월드", category: "식비", amount: -10000 },
-                { name: "오커스토리", category: "식비", amount: -13000 },
-            ],
-        },
-        {
-            date: "10월 15일",
-            list: [
-                { name: "돈까스정원", category: "식비", amount: -15000 },
-                { name: "친구커피", category: "식비", amount: -26000 },
-            ],
-        },
-    ];
+            date: string;
+            list: { name: string; category: string; amount: number }[];
+        }[]
+    >([]);
 
+    const [totalCount, setTotalCount] = useState(0);
+
+    // ==================================================
+    // 1) 카테고리 피드백 로딩
+    // ==================================================
+    useEffect(() => {
+        const fetchFeedback = async () => {
+            try {
+                if (!year || !month) return;
+
+                const res = await getMonthlyFeedback(year, month);
+                const feedbackJson = JSON.parse(res.categoryFeedback || "{}");
+                const catFeedback = feedbackJson[label];
+                if (catFeedback) {
+                    setEvaluation(catFeedback);
+                    setAdvice("");
+                }
+            } catch (err) {
+                console.error("카테고리 피드백 로딩 실패", err);
+            }
+        };
+
+        fetchFeedback();
+    }, [year, month, categoryName]);
+
+
+    // ==================================================
+    // 2) 월 전체 트랜잭션 → 해당 카테고리만 필터링
+    // ==================================================
+    useEffect(() => {
+        const fetchCategoryTransactions = async () => {
+            try {
+                if (!year || !month || !label) return;
+
+                // 🔥 한글 "식비" → "FOOD" 자동 변환
+                const categoryKey = findCategoryKeyByLabel(label);
+                if (!categoryKey) return;
+
+                const daysInMonth = new Date(year, month, 0).getDate();
+                let allExpenses: any[] = [];
+
+                for (let day = 1; day <= daysInMonth; day++) {
+                    const dateStr = `${year}-${String(month).padStart(2, "0")}-${String(
+                        day
+                    ).padStart(2, "0")}`;
+
+                    try {
+                        const res = await getTransaction(dateStr);
+                        const expenses = res.filter(
+                            (t: any) => t.incomeType === "EXPENSE"
+                        );
+                        allExpenses.push(...expenses);
+                    } catch { }
+                }
+
+                // 중복 제거
+                allExpenses = Array.from(
+                    new Map(allExpenses.map((i) => [i.id, i])).values()
+                );
+
+                // 🔥 영어 key 기준으로 필터링 (완벽 매칭)
+                const filtered = allExpenses.filter((item) => {
+                    const cat = item.category as CategoryType;
+                    return cat === categoryKey;
+                });
+
+                setTotalCount(filtered.length);
+
+                // 날짜별 묶기
+                const dailyMap: Record<string, any[]> = {};
+
+                filtered.forEach((item) => {
+                    const dateKey = item.dateTime.split("T")[0];
+
+                    if (!dailyMap[dateKey]) dailyMap[dateKey] = [];
+
+                    dailyMap[dateKey].push({
+                        name: item.itemName,
+                        category: label, // 한글 표시
+                        amount: -item.price,
+                    });
+                });
+
+                const grouped = Object.entries(dailyMap)
+                    .sort(([a], [b]) => (a < b ? 1 : -1))
+                    .map(([date, list]) => ({ date, list }));
+
+                setDailyHistory(grouped);
+            } catch (err) {
+                console.error("카테고리 상세 내역 불러오기 실패", err);
+            }
+        };
+
+        fetchCategoryTransactions();
+    }, [year, month, label]);
+
+    const getDetailMascotImage = (status: string | undefined) => {
+        if (status === "DAY") return IMAGES.MASCOT.HALF.DAY;
+        if (status === "TO") return IMAGES.MASCOT.HALF.TO;
+        return IMAGES.MASCOT.HALF.NOT; // 기본값
+    };
+    const MASCOT_COLOR_MAP: Record<string, string> = {
+        DAY: "text-primary-green",   // 초록
+        TO: "text-yellow-500",       // 노랑
+        NOT: "text-primary-red"      // 빨강
+    };
+    const currentColor = MASCOT_COLOR_MAP[mascotStatus] || "text-primary-green";
+
+    // ==================================================
+    // UI 
+    // ==================================================
     return (
         <div className="p-4 flex flex-col gap-4 bg-app-bg pb-6">
 
             {/* Header */}
             <div className="relative flex items-center py-2 mb-2">
-                <button className="text-2xl absolute left-0" onClick={() => navigate(-1)}>
+                <button className="text-2xl absolute left-0" onClick={() => navigate("/report", { state: { year, month } })}>
                     &lt;
                 </button>
                 <p className="text-lg font-semibold absolute left-1/2 -translate-x-1/2">
@@ -43,72 +178,61 @@ const CategoryDetailPage = () => {
                 </p>
             </div>
 
-            {/* 카테고리명 */}
-            <p className="text-text-gray text-sm">{categoryName}</p>
+            <p className="text-text-gray text-sm">{label}</p>
 
-            {/* 총 금액 */}
-            <p className="text-primary-green text-3xl font-bold">
-                {formatCurrency(totalAmount)}원
+            <p className="text-primary-red text-3xl font-bold">
+                -{formatCurrency(amount)}원
             </p>
 
-            {/* --- 🔥 1번째 카드 : 분석 텍스트 & 개구리 --- */}
-            <Card className="p-5 flex justify-between items-start">
-                <div>
+            {/* 소비 분석 */}
+            <Card className="p-5 flex justify-between items-start relative">
+                <div className="pr-28">
                     <p className="text-text-gray text-sm">
-                        데이터의 <span className="text-primary-green font-semibold">{categoryName}</span> 소비 분석
+                        <span className={`${currentColor} font-semibold`}>{mascotStatus}</span>의{" "}
+                        <span className={`${currentColor} font-semibold`}>{label}</span>{" "}
+                        소비 분석
                     </p>
 
-                    <p className="text-text-primary text-sm leading-[1.3] mt-2">
-                        야식으로 지출을 너무 자주 먹네요. <br />
-                        야식을 3번 줄여봐요!
+                    <p className="text-text-primary text-sm leading-[1.4] mt-2">
+                        {evaluation || "해당 카테고리의 소비 분석을 불러오는 중이에요"}
+                        {advice && (
+                            <span className="block text-text-gray mt-1">{advice}</span>
+                        )}
                     </p>
                 </div>
 
                 <img
-                    src={IMAGES.MASCOT.HALF.DAY}
-                    className="
-                    absolute
-                    right-8
-                    w-[125px]
-                    h-[125px]
-                    object-contain
-                    translate-y-[-9px]     /* 살짝 아래로 내려서 자연스럽게 */
-                    "
+                    src={getDetailMascotImage(mascotStatus)}
+                    className="absolute right-0 w-[125px] h-[125px] object-contain translate-y-[0px]"
                     alt="frog mascot"
                 />
             </Card>
 
-            {/* --- 🔥 2번째 & 3번째 카드 : 반원차트 + 전체 개수 --- */}
+            {/* 비율 */}
             <div className="grid grid-cols-2 gap-3">
-
-                {/* 반원차트 */}
                 <Card className="flex flex-col items-center justify-center py-5">
                     <p className="text-text-gray text-xs mb-2">
-                        전체 지출 10번 중 비율
+                        전체 소비 중 {label} 비율
                     </p>
-
-                    {/* 글씨 크기 줄이기 */}
                     <ProgressCircle current={percent} goal={100} mode="percent" />
                 </Card>
 
-                {/* 전체 소비 개수 */}
                 <Card className="flex flex-col items-center justify-center py-5">
                     <p className="text-text-gray text-xs">이번달 전체 소비 개수</p>
-
-                    <p className="text-primary-green text-2xl font-bold mt-1">
+                    <p className={`text-2xl font-bold mt-1 ${currentColor}`}>
                         총 {totalCount}개
                     </p>
-
-                    <p className="text-text-gray text-sm mt-1">
-                        {totalCountPercent}%
-                    </p>
+                    <p className="text-text-gray text-sm mt-1">{percent}%</p>
                 </Card>
             </div>
 
-            {/* --- 🔥 날짜별 내역 카드들 --- */}
+            {/* 날짜별 내역 */}
             {dailyHistory.map((day, idx) => (
                 <Card key={idx} className="p-4 flex flex-col gap-3">
-                    <p className="text-text-gray text-sm font-semibold">{day.date}</p>
+                    <p className="text-text-gray text-sm font-semibold">
+                        {new Date(day.date).getMonth() + 1}월{" "}
+                        {new Date(day.date).getDate()}일
+                    </p>
 
                     {day.list.map((item, i) => (
                         <div key={i} className="flex justify-between items-center">

--- a/t3-front/src/pages/IncomeDetailPage.tsx
+++ b/t3-front/src/pages/IncomeDetailPage.tsx
@@ -6,6 +6,7 @@ import { getTransaction, getMonthlyAmount } from "../api";
 import { useState, useEffect, useRef } from "react";
 import { IncomeCategoryLabel } from "../types";
 import type { IncomeCategoryType } from "../types";
+import SpendingItem from "../components/spending/SpendingItem";
 
 const safeIncomeCategory = (cat: string): IncomeCategoryType => {
     if (cat in IncomeCategoryLabel) {
@@ -235,7 +236,7 @@ const IncomeDetailPage = () => {
                                 </span>
                             </div>
 
-                            <span className="text-text-green font-semibold">
+                            <span className="text-black">
                                 +{formatCurrency(item.amount)}원
                             </span>
                         </div>
@@ -252,16 +253,13 @@ const IncomeDetailPage = () => {
                     </p>
 
                     {day.list.map((item, i) => (
-                        <div key={i} className="flex justify-between items-center">
-                            <div className="flex flex-col">
-                                <span className="font-medium">{item.name}</span>
-                                <span className="text-xs text-text-gray">{item.category}</span>
-                            </div>
-
-                            <span className="text-text-green font-semibold">
-                                +{formatCurrency(item.amount)}원
-                            </span>
-                        </div>
+                        <SpendingItem
+                            key={i}
+                            type="INCOME"                  // 수입
+                            name={item.name}
+                            category={item.category}
+                            price={formatCurrency(item.amount)}
+                        />
                     ))}
                 </Card>
             ))}

--- a/t3-front/src/pages/IncomeDetailPage.tsx
+++ b/t3-front/src/pages/IncomeDetailPage.tsx
@@ -1,0 +1,135 @@
+import { useNavigate } from "react-router-dom";
+import Card from "../components/common/Card";
+import CategoryDonutChart from "../components/charts/CategoryDonutChart";
+import { formatCurrency } from "../utils/";
+
+const IncomeDetailPage = () => {
+    const navigate = useNavigate();
+
+    // 🔥 더미 데이터 (서버 연결 후 교체)
+    const totalIncomeAmount = 600000;
+
+    const categoryStats = {
+        values: [350000, 90000, 45000, 30000],
+        colors: ["#FFA559", "#FFE16C", "#8FD694", "#6DD3FF"],
+        list: [
+            { label: "식비", amount: 135000, percent: 25, color: "#FFA559" },
+            { label: "약속", amount: 90000, percent: 20, color: "#FFE16C" },
+            { label: "놀거리", amount: 45000, percent: 15, color: "#8FD694" },
+            { label: "교통비", amount: 30000, percent: 10, color: "#6DD3FF" },
+        ],
+    };
+
+    const dailyHistory = [
+        {
+            date: "10월 20일",
+            list: [
+                { name: "디저트월드", category: "식비", amount: 10000 },
+                { name: "오커스토리", category: "식비", amount: -13000 },
+            ],
+        },
+        {
+            date: "10월 15일",
+            list: [
+                { name: "돈까스정원", category: "식비", amount: -15000 },
+                { name: "친구커피", category: "식비", amount: -26000 },
+            ],
+        },
+    ];
+
+    return (
+        <div className="p-4 flex flex-col gap-4 bg-app-bg">
+
+            {/* Header */}
+            <div className="flex items-center justify-between">
+                <button className="text-2xl" onClick={() => navigate(-1)}>
+                    &lt;
+                </button>
+
+                <p className="text-lg font-semibold">2025년 10월 수입</p>
+
+                <div className="w-5"></div>
+            </div>
+
+            {/* 총 수입 */}
+            <p className="text-text-green text-2xl font-bold">
+                +{formatCurrency(totalIncomeAmount)}원
+            </p>
+
+            {/* 도넛 차트 + 리스트 */}
+            <Card className="p-6 flex flex-col gap-5">
+
+                {/* 상단 텍스트 */}
+                <div className="flex justify-between items-center">
+                    <p className="text-text-gray text-sm">이번달 분야별 수입 통계</p>
+                    <p className="text-text-gray text-sm">
+                        총 {formatCurrency(totalIncomeAmount)}원
+                    </p>
+                </div>
+
+                {/* 도넛 차트 */}
+                <div className="flex justify-center">
+                    <CategoryDonutChart
+                        data={categoryStats.values}
+                        colors={categoryStats.colors}
+                        centerText={formatCurrency(totalIncomeAmount)}
+                    />
+                </div>
+
+                {/* 카테고리 리스트 */}
+                <div className="flex flex-col gap-3 mt-4">
+                    {categoryStats.list.map((item, idx) => (
+                        <div key={idx} className="flex justify-between items-center text-sm">
+                            <div className="flex items-center gap-2">
+                                <span
+                                    className="w-3 h-3 rounded-full"
+                                    style={{ backgroundColor: item.color }}
+                                ></span>
+                                <span className="text-text-primary">
+                                    {item.label} ({item.percent}%)
+                                </span>
+                            </div>
+
+                            <span className="text-primary-red">
+                                -{formatCurrency(item.amount)}원
+                            </span>
+                        </div>
+                    ))}
+                </div>
+
+            </Card>
+
+            {/* 날짜별 내역 */}
+            {dailyHistory.map((day, idx) => (
+                <Card key={idx} className="p-4 flex flex-col gap-3">
+
+                    <p className="text-text-gray text-sm font-semibold">{day.date}</p>
+
+                    {day.list.map((item, i) => (
+                        <div key={i} className="flex justify-between items-center">
+                            <div className="flex flex-col">
+                                <span className="font-medium">{item.name}</span>
+                                <span className="text-xs text-text-gray">{item.category}</span>
+                            </div>
+
+                            <span
+                                className={
+                                    item.amount > 0
+                                        ? "text-text-green font-semibold"
+                                        : "text-primary-red font-semibold"
+                                }
+                            >
+                                {item.amount > 0 ? "+" : ""}
+                                {formatCurrency(item.amount)}원
+                            </span>
+                        </div>
+                    ))}
+
+                </Card>
+            ))}
+
+        </div>
+    );
+};
+
+export default IncomeDetailPage;

--- a/t3-front/src/pages/ReportPage.tsx
+++ b/t3-front/src/pages/ReportPage.tsx
@@ -1,11 +1,291 @@
-import React from "react";
+import { useState } from "react";
+import Card from "../components/common/Card";
+import ProgressBar from "../components/charts/ProgressBar";
+import CategoryDonutChart from "../components/charts/CategoryDonutChart";
+
+import { IMAGES } from "../constants";
+import { formatCurrency } from "../utils/";
+import { useNavigate } from "react-router-dom";
 
 const ReportPage = () => {
+  const [showDetail, setShowDetail] = useState(false);
+
+  // -----------------------------
+  // 🔥 더미 데이터
+  // -----------------------------
+  const goal = {
+    targetCount: 3,
+    currentCount: 2,
+    goalName: "배달음식 5번 미만",
+  };
+
+  const totalIncomeAmount = 600000;
+  const totalExpenseAmount = 350000;
+  const totalGoalAmount = 200000;
+
+  const totalExpenseCount = 37;
+  const impulseCount = 7;
+  const plannedCount = 30;
+
+  const [year, setYear] = useState(2025);
+  const [month, setMonth] = useState(10);
+
+  const navigate = useNavigate();
+
+
+  const categoryStats = {
+    values: [135000, 90000, 45000, 30000],
+    colors: ["#FF9F5B", "#FFD86E", "#7BDDA1", "#6DD3FF"],
+    list: [
+      { label: "식비", amount: 135000, percent: 25 },
+      { label: "약속", amount: 90000, percent: 20 },
+      { label: "놀거리", amount: 45000, percent: 15 },
+      { label: "교통비", amount: 30000, percent: 10 },
+    ].map((item, i) => ({ ...item, color: ["#FF9F5B", "#FFD86E", "#7BDDA1", "#6DD3FF"][i] })),
+  };
+  const goPrevMonth = () => {
+    if (month === 1) {
+      setYear(year - 1);
+      setMonth(12);
+    } else {
+      setMonth(month - 1);
+    }
+  };
+
+  const goNextMonth = () => {
+    if (month === 12) {
+      setYear(year + 1);
+      setMonth(1);
+    } else {
+      setMonth(month + 1);
+    }
+  };
+
+
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-bold">Report</h1>
-      <p>리포트 화면입니다.</p>
-    </div>
+    <div className="p-4 flex flex-col gap-4 bg-app-bg">
+
+      {/* 월 이동 */}
+      <div className="w-full flex items-center justify-between px-2 py-3">
+        <button
+          onClick={goPrevMonth}
+          className="text-[20px] text-text-gray font-light"
+        >
+          &lt;
+        </button>
+
+        <p className="text-text-gray font-semibold text-lg">
+          {year}년 {month}월
+        </p>
+
+        <button
+          onClick={goNextMonth}
+          className="text-[20px] text-text-gray font-light"
+        >
+          &gt;
+        </button>
+      </div>
+      {/* ----------------------- */}
+      {/* 이번달 요약 (좌/우 두 카드) */}
+      {/* ----------------------- */}
+
+      <div className="flex gap-3 items-stretch">
+        {/* 왼쪽: 요약 카드 */}
+        <Card className="flex-1 p-5 flex flex-col gap-2">
+
+          <div className="flex justify-between items-start">
+            <p className="text-text-gray text-xs">이번달 요약</p>
+
+            {/* 자세히 보기 버튼 */}
+            <button
+              onClick={() => setShowDetail((prev) => !prev)}
+              className="text-xs text-text-gray"
+            >
+              {showDetail ? "접기 ▲" : "자세히 보기 ▼"}
+            </button>
+          </div>
+
+          <p className="text-text-primary font-semibold text-[14px] mt-1">
+            목표 {goal.currentCount}개 중 {goal.targetCount}개 달성했어요!
+          </p>
+
+          {/* 자세히 보기 영역 */}
+          {showDetail && (
+            <p className="text-text-gray text-[13px] mt-1 leading-[1.3]">
+              저번달에 비해 약속을 덜 나갔어요! <br />
+              하지만 야식이 저번 달에 비해 2번 늘어서 목표 예산을 넘어갔어요.
+            </p>
+          )}
+        </Card>
+
+        {/* 오른쪽: 마스코트 카드 (작은 카드) */}
+        <Card className="w-[110px] flex items-center justify-center p-3">
+          <img
+            src={IMAGES.MASCOT.ACTIVE.DAY}
+            className={`w-[4.5rem] transition-all duration-300 ${showDetail ? "h-[7rem]" : "h-[4.5rem]"
+              }`}
+            alt="mascot"
+          />
+        </Card>
+      </div>
+
+
+      {/* ----------------------- */}
+      {/* 이번달 목표 + 예산 (2개의 카드, 가로 배치) */}
+      {/* ----------------------- */}
+      <div className="flex gap-3">
+
+        {/* 왼쪽: 이번달 목표 */}
+        <Card className="flex-1 p-5 flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <p className="text-text-gray text-sm">이번달 목표</p>
+            <span className="text-xs bg-[#D7F7C6] text-green-700 px-2 py-1 rounded-md">
+              달성
+            </span>
+          </div>
+
+          <p className="text-text-primary text-lg font-semibold">
+            {goal.goalName}
+          </p>
+
+          <p className="text-text-gray text-sm">
+            총 {goal.currentCount}번, 목표를 달성했어요!
+          </p>
+        </Card>
+
+        {/* 오른쪽: 이번달 예산 */}
+        <Card className="flex-1 p-5 flex flex-col gap-2">
+          <div className="flex items-center gap-2 justify-between">
+            <p className="text-text-gray text-sm">이번달 예산</p>
+
+            <span className="text-xs bg-gray-200 text-gray-600 px-2 py-1 rounded-md">
+              미달성
+            </span>
+          </div>
+
+          <div>
+            <p className="text-text-gray text-xs">이번달 총 소비</p>
+            <p className="text-primary-red text-xl font-bold">
+              -{formatCurrency(totalExpenseAmount)}원
+            </p>
+          </div>
+
+          <div>
+            <p className="text-text-gray text-xs">이번달 총 소비 목표 비용</p>
+            <p className="text-text-primary text-lg font-semibold">
+              {formatCurrency(totalGoalAmount)}원
+            </p>
+          </div>
+        </Card>
+
+      </div>
+      {/* ----------------------- */}
+      {/* 계획 / 즉흥 소비 */}
+      {/* ----------------------- */}
+      <Card className="p-5 flex flex-col gap-4">
+        <div className="flex justify-between items-center">
+          <p className="text-text-gray text-sm">이번달 계획소비 개수</p>
+          <p className="text-text-gray text-sm">총 {totalExpenseCount}개</p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <img
+            src={IMAGES.MASCOT.SINGLE.NOT}
+            className="w-[3rem] h-[3rem]"
+          />
+          <ProgressBar
+            label="즉흥"
+            value={impulseCount}
+            total={totalExpenseCount}
+            variant="red"
+          />
+        </div>
+
+        {/* 계획 소비 */}
+        <div className="flex items-center gap-3">
+          <img
+            src={IMAGES.MASCOT.SINGLE.DAY}
+            className="w-[3rem] h-[3rem]"
+          />
+          <ProgressBar
+            label="계획"
+            value={plannedCount}
+            total={totalExpenseCount}
+            variant="green"
+          />
+        </div>
+      </Card>
+
+      {/* ----------------------- */}
+      {/* 이번달 총 수입 */}
+      {/* ----------------------- */}
+      <Card
+        className="flex flex-row items-center justify-between px-6 py-4 cursor-pointer"
+        onClick={() => navigate("/income")}
+      >
+        {/* 왼쪽: 제목 + 금액을 한 줄로 */}
+        <div className="flex items-center gap-3 whitespace-nowrap">
+          <span className="text-text-gray text-sm">이번달 총 수입</span>
+          <span className="text-text-green font-bold text-base">
+            +{formatCurrency(totalIncomeAmount)}원
+          </span>
+        </div>
+
+        {/* 오른쪽 > */}
+        <span className="text-text-gray text-xl flex-shrink-0">&gt;</span>
+      </Card>
+
+
+      {/* ----------------------- */}
+      {/* 카테고리 도넛 차트 */}
+      {/* ----------------------- */}
+      <Card className="p-6 flex flex-col gap-6">
+        <div className="flex justify-between">
+          <p className="text-text-gray text-sm">이번달 분야별 지출 통계</p>
+          <p className="text-text-gray text-sm">
+            총 {formatCurrency(totalExpenseAmount)}원
+          </p>
+        </div>
+
+        <div className="flex justify-center">
+          <CategoryDonutChart
+            data={categoryStats.values}
+            colors={categoryStats.colors}
+            centerText={formatCurrency(totalExpenseAmount)}
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          {categoryStats.list.map((item, idx) => (
+            <div
+              key={idx}
+              className="flex justify-between items-center text-sm cursor-pointer"
+              onClick={() => navigate(`/report/category/${item.label}`)}
+            >
+              <div className="flex items-center gap-2">
+                <span
+                  className="w-3 h-3 rounded-full"
+                  style={{ backgroundColor: item.color }}
+                ></span>
+
+                <span className="text-text-primary">
+                  {item.label} ({item.percent}%)
+                </span>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <span className="text-primary-red">
+                  -{formatCurrency(item.amount)}원
+                </span>
+
+                {/* ➜ 오른쪽 화살표 */}
+                <span className="text-text-gray text-lg">&gt;</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </Card >
+    </div >
   );
 };
 

--- a/t3-front/src/pages/ReportPage.tsx
+++ b/t3-front/src/pages/ReportPage.tsx
@@ -368,8 +368,9 @@ const ReportPage = () => {
         <Card className="w-[110px] flex items-center justify-center p-3">
           <img
             src={getMascotImage()}
-            className={`w-[4.5rem] transition-all duration-300 ${showDetail ? "h-[7rem]" : "h-[4.5rem]"
-              }`}
+            className={`transition-all duration-300 
+              ${showDetail ? "w-[6rem] h-[7rem]" : "w-[5.5rem] h-[5.5rem]"}
+              object-contain`}
             alt="mascot"
           />
         </Card>
@@ -377,64 +378,102 @@ const ReportPage = () => {
 
       {/* 이번달 목표/예산 */}
       <div className="flex gap-3">
-        <Card className="flex-1 p-5 flex flex-col gap-1">
+        <Card className="flex-1 p-5 flex flex-col gap-2">
           <div className="flex items-center gap-2">
-            <p className="text-text-gray text-sm">이번달 목표</p>
+            <p className="text-text-gray text-xs">이번달 목표</p>
 
             {loadingGoal ? (
-              <span className="text-xs bg-gray-200 text-gray-600 px-2 py-1 rounded-md">
+              <span className="text-[10px] bg-gray-200 text-gray-600 px-2 py-0.5 rounded-md">
                 로딩중
               </span>
             ) : isAchieved ? (
-              <span className="text-xs bg-[#D7F7C6] text-green-700 px-2 py-1 rounded-md">
+              <span className="text-[10px] bg-[#D7F7C6] text-green-700 px-2 py-0.5 rounded-md flex items-center gap-1">
+                <svg
+                  className="w-3 h-3 text-green-700"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
                 달성
               </span>
             ) : (
-              <span className="text-xs bg-gray-200 text-gray-600 px-2 py-1 rounded-md">
+              <span className="text-[10px] bg-gray-200 text-gray-600 px-2 py-0.5 rounded-md flex items-center gap-1">
+                <svg
+                  className="w-3 h-3 text-gray-600"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
                 미달성
               </span>
             )}
           </div>
 
-          <p className="text-text-primary text-lg font-semibold">
+          {/* 제목 - 폰트 조금 줄임 */}
+          <p className="text-text-primary text-base font-semibold mt-1">
             {loadingGoal ? "목표 불러오는 중..." : goalData.goal}
           </p>
 
-          <p className="text-text-gray text-sm">
+          {/* 설명 - 위쪽 간격 추가! */}
+          <p className="text-text-gray text-xs mt-5 leading-relaxed">
             목표 소비 횟수 {goalData.targetCount}번 중{" "}
             {goalData.currentCount}번 소비했어요!
           </p>
         </Card>
 
         <Card className="flex-1 p-5 flex flex-col gap-2">
-          <div className="flex items-center gap-2 justify-between">
-            <p className="text-text-gray text-sm">이번달 예산</p>
+          <div className="flex items-center justify-between">
+            <p className="text-text-gray text-xs">이번달 예산</p>
 
             {loadingAmount ? (
-              <span className="text-xs bg-gray-200 text-gray-600 px-2 py-1 rounded-md">
+              <span className="text-[10px] bg-gray-200 text-gray-600 px-2 py-0.5 rounded-md">
                 로딩중
               </span>
             ) : isBudgetAchieved ? (
-              <span className="text-xs bg-[#D7F7C6] text-green-700 px-2 py-1 rounded-md">
+              <span className="text-[10px] bg-[#D7F7C6] text-green-700 px-2 py-0.5 rounded-md flex items-center gap-1">
+                <svg
+                  className="w-3 h-3 text-green-700"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
                 달성
               </span>
             ) : (
-              <span className="text-xs bg-gray-200 text-gray-600 px-2 py-1 rounded-md">
+              <span className="text-[10px] bg-gray-200 text-gray-600 px-2 py-0.5 rounded-md flex items-center gap-1">
+                <svg
+                  className="w-3 h-3 text-gray-600"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
                 미달성
               </span>
             )}
           </div>
 
-          <div>
-            <p className="text-text-gray text-xs">이번달 총 소비</p>
-            <p className="text-primary-red text-xl font-bold">
+          <div className="mt-1">
+            <p className="text-text-gray text-[11px]">이번달 총 소비</p>
+            <p className="text-primary-red text-lg font-bold">
               -{formatCurrency(monthlyAmount.totalExpenseAmount)}원
             </p>
           </div>
 
-          <div>
-            <p className="text-text-gray text-xs">이번달 총 소비 목표 비용</p>
-            <p className="text-text-primary text-lg font-semibold">
+          <div className="mt-1">
+            <p className="text-text-gray text-[11px]">이번달 총 소비 목표 비용</p>
+            <p className="text-text-primary text-base font-semibold">
               {formatCurrency(monthlyAmount.totalGoalAmount)}원
             </p>
           </div>
@@ -532,7 +571,7 @@ const ReportPage = () => {
               </div>
 
               <div className="flex items-center gap-2">
-                <span className="text-primary-red">
+                <span className="text-black">
                   -{formatCurrency(item.amount)}원
                 </span>
                 <span className="text-text-gray text-lg">&gt;</span>

--- a/t3-front/src/types/calendar.ts
+++ b/t3-front/src/types/calendar.ts
@@ -43,14 +43,14 @@ export const IncomeCategory = {
 } as const;
 
 export const IncomeCategoryLabel: Record<keyof typeof IncomeCategory, string> =
-  {
-    SALARY: "급여",
-    ALLOWANCE: "용돈",
-    REFUND: "환급",
-    INTEREST: "이자",
-    ETC: "기타",
-    SIDE: "부수입",
-  };
+{
+  SALARY: "급여",
+  ALLOWANCE: "용돈",
+  REFUND: "환급",
+  INTEREST: "이자",
+  ETC: "기타",
+  SIDE: "부수입",
+};
 
 export type ExpenseCategoryType =
   (typeof ExpenseCategory)[keyof typeof ExpenseCategory];
@@ -114,6 +114,6 @@ export interface MonthlySummaryFeedbackResponse {
   month: string;
   uptoDate: string;
   summary: string;
-  summary_detailed: string;
+  summary2: string;
   categoryFeedback: string;
 }


### PR DESCRIPTION
## 🚀 Background
소비레포트 화면 구성

## 🥥 Changes
- 소비레포트 메인 화면 구현
- 각 카테고리별 레포트 화면 구현
- 매달 수입 분포도 화면 구현
- 원형 도넛 차트 컴포넌트 추가

## 🧪 Testing
- ✅ : 작동 확인
- ❌ : 백엔드 연동 X, 더미 값으로 이루어진 상태

## 📸 Screenshots
- 
<img width="275" height="598" alt="image" src="https://github.com/user-attachments/assets/26576c52-bc02-4dd6-806b-584b741983d0" />
<img width="280" height="592" alt="image" src="https://github.com/user-attachments/assets/073029e9-d81c-48a4-893e-dc587e23cb85" />
<img width="271" height="590" alt="image" src="https://github.com/user-attachments/assets/8fa4a614-84db-4dcd-bc68-b24b1a55b2b7" />

## ✍🏻 References
- 참고한 레퍼런스

## ⚓ Related Issue
- closes #(feat/#4) 
